### PR TITLE
Docs : Android/iOS interactor capabilities

### DIFF
--- a/cdn-load-balancer/android/ExoPlayerCDNLoadBalancer/README.md
+++ b/cdn-load-balancer/android/ExoPlayerCDNLoadBalancer/README.md
@@ -325,3 +325,23 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with CDN Load Balancer SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported

--- a/cdn-load-balancer/android/ExoPlayerCDNLoadBalancerJava/README.md
+++ b/cdn-load-balancer/android/ExoPlayerCDNLoadBalancerJava/README.md
@@ -318,3 +318,23 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with CDN Load Balancer SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported

--- a/cdn-load-balancer/android/ExoPlayerCDNLoadBalancerPlugin/README.md
+++ b/cdn-load-balancer/android/ExoPlayerCDNLoadBalancerPlugin/README.md
@@ -377,3 +377,23 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with CDN Load Balancer SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported

--- a/cdn-load-balancer/android/THEOplayerCDNLoadBalancerJava/README.md
+++ b/cdn-load-balancer/android/THEOplayerCDNLoadBalancerJava/README.md
@@ -344,3 +344,23 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with CDN Load Balancer SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported

--- a/mesh-delivery/android/ExoPlayerMeshDelivery/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDelivery/README.md
@@ -1,35 +1,5 @@
 # Mesh Delivery SDK Integration for Android (Kotlin)
 
-## Interactor capabilities
-The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
-Each player has a different API that the SDK tries to use at its full potential. The lack of some interfaces may :
-- Reduce QoS detection
-- Reduce efficiency
-
-### QoS
-
-**States**
-* INVALID : Unused
-* IDLE : OK
-* PLAYING : OK
-* PAUSED : OK
-* SEEKING : OK
-* REBUFFERING : OK
-* ENDED : OK
-
-**Misc**
-* Playback time : OK
-* Bandwidth control : OK
-* Buffer health : OK
-* Track switch : Unreliable
-* Player error : OK
-* Frame drop : Unsupported
-
-### Efficiency
-
-* Set buffer target : OK
-* Get buffer target : OK
-
 ## Prerequisite
 To integrate the Mesh Delivery SDK, we need:
 * A valid Delivery Client Key (formerly Streamroot Key). It is available in the Account section of your dashboard.
@@ -353,3 +323,33 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with Mesh Delivery SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+The lack of some interfaces may :
+- Reduce QoS detection
+- Reduce offload
+
+### QoS
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Bandwidth control : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported
+
+### Offload
+* Set buffer target : OK
+* Get buffer target : OK

--- a/mesh-delivery/android/ExoPlayerMeshDelivery/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDelivery/README.md
@@ -1,5 +1,35 @@
 # Mesh Delivery SDK Integration for Android (Kotlin)
 
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential. The lack of some interfaces may :
+- Reduce QoS detection
+- Reduce efficiency
+
+### QoS
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Bandwidth control : OK
+* Buffer health : OK
+* Track switch : Unreliable
+* Player error : OK
+* Frame drop : Unsupported
+
+### Efficiency
+
+* Set buffer target : OK
+* Get buffer target : OK
+
 ## Prerequisite
 To integrate the Mesh Delivery SDK, we need:
 * A valid Delivery Client Key (formerly Streamroot Key). It is available in the Account section of your dashboard.

--- a/mesh-delivery/android/ExoPlayerMeshDeliveryJava/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDeliveryJava/README.md
@@ -316,3 +316,33 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with Mesh Delivery SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+The lack of some interfaces may :
+- Reduce QoS detection
+- Reduce offload
+
+### QoS
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Bandwidth control : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported
+
+### Offload
+* Set buffer target : OK
+* Get buffer target : OK

--- a/mesh-delivery/android/ExoPlayerMeshDeliveryPlugin/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDeliveryPlugin/README.md
@@ -377,3 +377,33 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with Mesh Delivery SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+The lack of some interfaces may :
+- Reduce QoS detection
+- Reduce offload
+
+### QoS
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Bandwidth control : OK
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported
+
+### Offload
+* Set buffer target : OK
+* Get buffer target : OK

--- a/mesh-delivery/android/THEOplayerMeshDeliveryJava/README.md
+++ b/mesh-delivery/android/THEOplayerMeshDeliveryJava/README.md
@@ -344,3 +344,33 @@ dcStatsView = ...
 initStatsView(dcStatsView)
 ```
 A red overlay with Mesh Delivery SDK related stats should be displayed. The stats view overlay can be reopened by clicking repeatedly anywhere on the screen.
+
+## Interactor capabilities
+The SDK is player agnostic. All communication between the player and the delivery client that are player specific are implemented in a PlayerInteractor class.
+Each player has a different API that the SDK tries to use at its full potential in order to monitor and maximize the Quality of Service.
+The lack of some interfaces may :
+- Reduce QoS detection
+- Reduce offload
+
+### QoS
+
+**States**
+* INVALID : Unused
+* IDLE : OK
+* PLAYING : OK
+* PAUSED : OK
+* SEEKING : OK
+* REBUFFERING : OK
+* ENDED : OK
+
+**Misc**
+* Playback time : OK
+* Bandwidth control : Unsupported
+* Buffer health : OK
+* Track switch : Experimental
+* Player error : OK
+* Frame drop : Unsupported
+
+### Offload
+* Set buffer target : OK
+* Get buffer target : OK


### PR DESCRIPTION
Adds interactor capabilities information in the README of all supported mesh delivery / cdn load balancer players.