### PR TITLE
Fixing sample app link

### DIFF
--- a/mesh-delivery/android/ExoPlayerMeshDelivery/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDelivery/README.md
@@ -8,7 +8,7 @@ To integrate the Mesh Delivery SDK, we need:
 
 **NOTE:** For this sample app, we are using `demoswebsiteandpartners` Delivery Client Key. If you do not have one, you can ask for a [free trial on our website](https://www.lumen.com/en-us/edge-computing/mesh-delivery.html). In the following tutorial, every mention to the Delivery Client Key will use the `<delivery-client-key>` placeholder.
 
-**Not into Tutorials?** Take a look at our [sample app](./) 
+**Not into Tutorials?** Take a look at our [sample app](https://github.com/streamroot/integration-samples/tree/master/mesh-delivery/android/ExoPlayerMeshDelivery) 
 
 ## SDK installation
 The easiest way to get the Mesh Delivery SDK is to add it as a Gradle dependency. We assume you are using Android Studio with the latest tools updates as recommended by Google. If not, write to us at [cdnsupport@lumen.com](mailto:cdnsupport@lumen.com).

--- a/mesh-delivery/android/ExoPlayerMeshDeliveryJava/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDeliveryJava/README.md
@@ -8,7 +8,7 @@ To integrate the Mesh Delivery SDK, we need:
 
 **NOTE:** For this sample app, we are using `demoswebsiteandpartners` Delivery Client Key. If you do not have one, you can ask for a [free trial on our website](https://www.lumen.com/en-us/edge-computing/mesh-delivery.html). In the following tutorial, every mention to the Delivery Client Key will use the `<delivery-client-key>` placeholder.
 
-**Not into Tutorials?** Take a look at our [sample app](./) 
+**Not into Tutorials?** Take a look at our [sample app](https://github.com/streamroot/integration-samples/tree/master/mesh-delivery/android/ExoPlayerMeshDeliveryJava) 
 
 ## SDK installation
 The easiest way to get the Mesh Delivery SDK is to add it as a Gradle dependency. We assume you are using Android Studio with the latest tools updates as recommended by Google. If not, write to us at [cdnsupport@lumen.com](mailto:cdnsupport@lumen.com).

--- a/mesh-delivery/android/ExoPlayerMeshDeliveryPlugin/README.md
+++ b/mesh-delivery/android/ExoPlayerMeshDeliveryPlugin/README.md
@@ -8,7 +8,7 @@ The Mesh Delivery plugin for ExoPlayer is an Android Archive maven artifact that
 ## Prerequisite
 To integrate the Mesh Delivery plugin for ExoPlayer, you will need a valid Delivery Client Key. It is available in the Account section of your dashboard. If you do not have one, you can ask for a [free trial on our website](https://www.lumen.com/en-us/edge-computing/mesh-delivery.html). In the following tutorial, every mention to the Delivery Client Key will use the `<delivery-client-key>` placeholder.
 
-**Not into Tutorials?** Take a look at our [sample app](./) 
+**Not into Tutorials?** Take a look at our [sample app](https://github.com/streamroot/integration-samples/tree/master/mesh-delivery/android/ExoPlayerMeshDeliveryPlugin) 
 
 ## Plugin installation
 The easiest way to get the Mesh Delivery plugin is to add it as a Gradle dependency. We assume you are using Android Studio with the latest tools updates as recommended by Google. If not, write to us at [cdnsupport@lumen.com](mailto:cdnsupport@lumen.com).

--- a/mesh-delivery/android/THEOplayerMeshDeliveryJava/README.md
+++ b/mesh-delivery/android/THEOplayerMeshDeliveryJava/README.md
@@ -8,7 +8,7 @@ To integrate the Mesh Delivery SDK, we need:
 
 **NOTE:** For this sample app, we are using `demoswebsiteandpartners` Delivery Client Key. If you do not have one, you can ask for a [free trial on our website](https://www.lumen.com/en-us/edge-computing/mesh-delivery.html). In the following tutorial, every mention to the Delivery Client Key will use the `<delivery-client-key>` placeholder.
 
-**Not into Tutorials?** Take a look at our [sample app](./) 
+**Not into Tutorials?** Take a look at our [sample app](https://github.com/streamroot/integration-samples/tree/master/mesh-delivery/android/ExoPlayerMeshDeliveryJava) 
 
 ## SDK installation
 The easiest way to get the Mesh Delivery SDK is to add it as a Gradle dependency. We assume you are using Android Studio with the latest tools updates as recommended by Google. If not, write to us at [cdnsupport@lumen.com](mailto:cdnsupport@lumen.com).

--- a/mesh-delivery/ios/AVPlayerMeshDelivery/README.md
+++ b/mesh-delivery/ios/AVPlayerMeshDelivery/README.md
@@ -7,7 +7,7 @@ To integrate the Mesh Delivery SDK, we need:
 
 **NOTE:** For this sample app, we are using `demoswebsiteandpartners` Delivery Client Key. If you do not have one, you can ask for a [free trial on our website](https://www.lumen.com/en-us/edge-computing/mesh-delivery.html). In the following tutorial, every mention to the Delivery Client Key will use the `<delivery-client-key>` placeholder.
 
-**Not into Tutorials?** Take a look at our [sample app](./) 
+**Not into Tutorials?** Take a look at our [sample app](https://github.com/streamroot/integration-samples/tree/master/mesh-delivery/ios/AVPlayerMeshDelivery) 
 
 ## Framework installation
 The Mesh Delivery SDK is delivered as an Xcode framework and is available on [Cocoapods](https://cocoapods.org/) and [Carthage](https://github.com/Carthage/Carthage#quick-start).

--- a/mesh-delivery/ios/AVPlayerMeshDeliveryPlugin/README.md
+++ b/mesh-delivery/ios/AVPlayerMeshDeliveryPlugin/README.md
@@ -7,7 +7,7 @@ To integrate the Mesh Delivery plugin for AVPlayer, we need:
 
 **NOTE:** For this sample app, we are using `demoswebsiteandpartners` Delivery Client Key. If you do not have one, you can ask for a [free trial on our website](https://www.lumen.com/en-us/edge-computing/mesh-delivery.html). In the following tutorial, every mention to the Delivery Client Key will use the `<delivery-client-key>` placeholder.
 
-**Not into Tutorials?** Take a look at our [sample app](./) 
+**Not into Tutorials?** Take a look at our [sample app](https://github.com/streamroot/integration-samples/tree/master/mesh-delivery/ios/AVPlayerMeshDeliveryPlugin) 
 
 ## Framework installation
 Mesh Delivery plugin for AVPlayer is delivered as an Xcode framework and is available on [Cocoapods](https://cocoapods.org/) and [Carthage](https://github.com/Carthage/Carthage#quick-start).


### PR DESCRIPTION
relative URL stayed on samples.edge-delivery.lumen.com and did not go to github to show the code. Fixed it with full github URL 